### PR TITLE
Feat(matrix): Add Data Matrix and Aztec code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Why QRose?
 - **Efficient** - declare and render codes synchronously right from the composition in 60+ fps;
 - **Scalable** - no raster bitmaps, only scalable vector graphics;
 - **Multiplatform** - supports all the targets supported by Compose Multiplatform.
-- **Multiformat** - multiple formats supported: `QR`, `UPC`, `EAN`, `Code 128/93/39`, `Codabar`, `ITF`.
+- **Multiformat** - multiple formats supported: `QR`, `Data Matrix`, `Aztec`, `UPC`, `EAN`, `Code 128/93/39`, `Codabar`, `ITF`.
 
 # Installation
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.alexzhirkevich/qrose)](https://central.sonatype.com/artifact/io.github.alexzhirkevich/qrose)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.alexzhirkevich:qrose)](https://central.sonatype.com/artifact/io.github.alexzhirkevich/qrose)
 
 ```gradle
 dependencies {
@@ -27,7 +27,10 @@ dependencies {
     // For QR codes
     implementation("io.github.alexzhirkevich:qrose:<latest_version>")
     
-    // For single-dimension barcodes (UPC,EAN, Code128, ...)
+    // For 2D matrix codes (Data Matrix, Aztec)
+    implementation("io.github.alexzhirkevich:qrose-matrix:<latest_version>")
+
+    // For single-dimension barcodes (UPC, EAN, Code128, ...)
     implementation("io.github.alexzhirkevich:qrose-oned:<latest_version>")
 }
 ```
@@ -36,13 +39,23 @@ dependencies {
 
 ## Basic
 
-You can create code right in composition using `rememberQrCodePainter`, `rememberBarcodePainter`.
-Or use `QrCodePainter`, `BarcodePainter` to create it outside of Compose. 
+You can create code right in composition using `rememberQrCodePainter`, `rememberDataMatrixPainter`, `rememberAztecPainter`, `rememberBarcodePainter`.
+Or use `QrCodePainter`, `DataMatrixPainter`, `AztecPainter`, `BarcodePainter` to create it outside of Compose. 
 
 ```kotlin
 Image(
     painter = rememberQrCodePainter("https://example.com"),
     contentDescription = "QR code referring to the example.com website"
+)
+
+Image(
+    painter = rememberDataMatrixPainter("https://example.com"),
+    contentDescription = "Data Matrix code"
+)
+
+Image(
+    painter = rememberAztecPainter("https://example.com"),
+    contentDescription = "Aztec code"
 )
 
 Image(

--- a/example/shared/build.gradle.kts
+++ b/example/shared/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":qrose"))
             implementation(project(":qrose-oned"))
+            implementation(project(":qrose-matrix"))
             implementation(compose.ui)
             implementation(compose.runtime)
             implementation(compose.material3)

--- a/example/shared/src/commonMain/kotlin/App.kt
+++ b/example/shared/src/commonMain/kotlin/App.kt
@@ -49,6 +49,9 @@ import io.github.alexzhirkevich.qrose.QrData
 import io.github.alexzhirkevich.qrose.email
 import io.github.alexzhirkevich.qrose.oned.BarcodeType
 import io.github.alexzhirkevich.qrose.oned.rememberBarcodePainter
+import io.github.alexzhirkevich.qrose.matrix.datamatrix.DataMatrixShape
+import io.github.alexzhirkevich.qrose.matrix.rememberAztecPainter
+import io.github.alexzhirkevich.qrose.matrix.rememberDataMatrixPainter
 import io.github.alexzhirkevich.qrose.options.Neighbors
 import io.github.alexzhirkevich.qrose.options.QrBallShape
 import io.github.alexzhirkevich.qrose.options.QrBrush
@@ -162,6 +165,30 @@ fun AllBarcodes() {
         OnedCode("Code 128", rememberBarcodePainter("test", BarcodeType.Code128))
         OnedCode("Codabar", rememberBarcodePainter("A23342453D", BarcodeType.Codabar))
         OnedCode("QR", rememberQrCodePainter("https://github.com/alexzhirkevich/qrose"))
+        TwodCode("Data Matrix (Square)", rememberDataMatrixPainter("https://github.com/alexzhirkevich/qrose"))
+        TwodCode("Data Matrix (Rect)", rememberDataMatrixPainter("DEMO12345", shape = DataMatrixShape.Rectangle))
+        TwodCode("Aztec", rememberAztecPainter("https://github.com/alexzhirkevich/qrose"))
+    }
+}
+
+@Composable
+fun TwodCode(
+    name: String,
+    code: Painter
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .padding(20.dp)
+            .border(1.dp, Color.Black)
+            .padding(10.dp)
+    ) {
+        Image(
+            painter = code,
+            contentDescription = null,
+            modifier = Modifier.size(150.dp)
+        )
+        Text(name)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 13 11:02:04 MSK 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/qrose-matrix/build.gradle.kts
+++ b/qrose-matrix/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    alias(libs.plugins.compose)
+    alias(libs.plugins.composeCompiler)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.ui)
+            api(project(":qrose-core"))
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/AztecPainter.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/AztecPainter.kt
@@ -1,0 +1,80 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import io.github.alexzhirkevich.qrose.matrix.aztec.AztecEncoder
+
+/**
+ * Remember Aztec barcode painter.
+ *
+ * @param data payload string
+ * @param errorCorrectionPercent minimum error correction percentage (default 33)
+ * @param userSpecifiedLayers optional explicit layer count (positive for full, negative for compact, 0 for auto)
+ * @param brush module brush (solid color or gradient)
+ * @param backgroundBrush optional background brush
+ * @param pixelShape module shape ([MatrixPixelShape.Default], [MatrixPixelShape.RoundCorners], [MatrixPixelShape.Circle])
+ * @param quietZone margin around the code in module units (Aztec standard specifies 0 quiet zone)
+ */
+@Composable
+public fun rememberAztecPainter(
+    data: String,
+    errorCorrectionPercent: Int = AztecEncoder.DEFAULT_EC_PERCENT,
+    userSpecifiedLayers: Int = AztecEncoder.DEFAULT_LAYERS,
+    brush: Brush = SolidColor(Color.Black),
+    backgroundBrush: Brush? = null,
+    pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    quietZone: Int = 0,
+): AztecPainter = remember(data, errorCorrectionPercent, userSpecifiedLayers, brush, backgroundBrush, pixelShape, quietZone) {
+    AztecPainter(
+        data = data,
+        errorCorrectionPercent = errorCorrectionPercent,
+        userSpecifiedLayers = userSpecifiedLayers,
+        brush = brush,
+        backgroundBrush = backgroundBrush,
+        pixelShape = pixelShape,
+        quietZone = quietZone
+    )
+}
+
+/**
+ * [MatrixBarcodePainter] for Aztec codes.
+ */
+@Immutable
+public class AztecPainter(
+    public val data: String,
+    public val errorCorrectionPercent: Int = AztecEncoder.DEFAULT_EC_PERCENT,
+    public val userSpecifiedLayers: Int = AztecEncoder.DEFAULT_LAYERS,
+    brush: Brush = SolidColor(Color.Black),
+    backgroundBrush: Brush? = null,
+    pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    quietZone: Int = 0,
+) : MatrixBarcodePainter(
+    matrix = AztecEncoder.encode(data, errorCorrectionPercent, userSpecifiedLayers),
+    brush = brush,
+    backgroundBrush = backgroundBrush,
+    pixelShape = pixelShape,
+    quietZone = quietZone
+) {
+    override fun toString(): String = "AztecPainter(data=$data, ecPercent=$errorCorrectionPercent)"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AztecPainter) return false
+        if (data != other.data) return false
+        if (errorCorrectionPercent != other.errorCorrectionPercent) return false
+        if (userSpecifiedLayers != other.userSpecifiedLayers) return false
+        return super.equals(other)
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + data.hashCode()
+        result = 31 * result + errorCorrectionPercent.hashCode()
+        result = 31 * result + userSpecifiedLayers.hashCode()
+        return result
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/DataMatrixPainter.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/DataMatrixPainter.kt
@@ -1,0 +1,75 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import io.github.alexzhirkevich.qrose.matrix.datamatrix.DataMatrixEncoder
+import io.github.alexzhirkevich.qrose.matrix.datamatrix.DataMatrixShape
+
+/**
+ * Remember Data Matrix barcode painter.
+ *
+ * @param data payload string
+ * @param shape shape hint ([DataMatrixShape.Auto], [DataMatrixShape.Square], [DataMatrixShape.Rectangle])
+ * @param brush module brush (solid color or gradient)
+ * @param backgroundBrush optional background brush
+ * @param pixelShape module shape ([MatrixPixelShape.Default], [MatrixPixelShape.RoundCorners], [MatrixPixelShape.Circle])
+ * @param quietZone margin around the code in module units (recommended at least 1)
+ */
+@Composable
+public fun rememberDataMatrixPainter(
+    data: String,
+    shape: DataMatrixShape = DataMatrixShape.Auto,
+    brush: Brush = SolidColor(Color.Black),
+    backgroundBrush: Brush? = null,
+    pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    quietZone: Int = 1,
+): DataMatrixPainter = remember(data, shape, brush, backgroundBrush, pixelShape, quietZone) {
+    DataMatrixPainter(
+        data = data,
+        shape = shape,
+        brush = brush,
+        backgroundBrush = backgroundBrush,
+        pixelShape = pixelShape,
+        quietZone = quietZone
+    )
+}
+
+/**
+ * [MatrixBarcodePainter] for Data Matrix (ECC 200) codes.
+ */
+@Immutable
+public class DataMatrixPainter(
+    public val data: String,
+    public val shape: DataMatrixShape = DataMatrixShape.Auto,
+    brush: Brush = SolidColor(Color.Black),
+    backgroundBrush: Brush? = null,
+    pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    quietZone: Int = 1,
+) : MatrixBarcodePainter(
+    matrix = DataMatrixEncoder.encode(data, shape),
+    brush = brush,
+    backgroundBrush = backgroundBrush,
+    pixelShape = pixelShape,
+    quietZone = quietZone
+) {
+    override fun toString(): String = "DataMatrixPainter(data=$data, shape=$shape)"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DataMatrixPainter) return false
+        if (data != other.data) return false
+        if (shape != other.shape) return false
+        return super.equals(other)
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + data.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/Matrix2D.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/Matrix2D.kt
@@ -1,0 +1,59 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * 2-dimensional boolean matrix representing barcode modules.
+ * `true` means a dark (foreground) module, `false` means a light (background) module.
+ */
+@Immutable
+public class Matrix2D(
+    public val width: Int,
+    public val height: Int
+) {
+    private val bits: BooleanArray = BooleanArray(width * height)
+
+    public operator fun get(x: Int, y: Int): Boolean {
+        require(x in 0 until width && y in 0 until height) {
+            "Coordinates ($x, $y) out of bounds for matrix size ${width}x${height}"
+        }
+        return bits[y * width + x]
+    }
+
+    public operator fun set(x: Int, y: Int, value: Boolean) {
+        require(x in 0 until width && y in 0 until height) {
+            "Coordinates ($x, $y) out of bounds for matrix size ${width}x${height}"
+        }
+        bits[y * width + x] = value
+    }
+
+    public fun copy(): Matrix2D {
+        val copy = Matrix2D(width, height)
+        bits.copyInto(copy.bits)
+        return copy
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Matrix2D) return false
+        if (width != other.width || height != other.height) return false
+        return bits.contentEquals(other.bits)
+    }
+
+    override fun hashCode(): Int {
+        var result = width
+        result = 31 * result + height
+        result = 31 * result + bits.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String = buildString {
+        append("Matrix2D(${width}x${height}):\n")
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                append(if (this@Matrix2D[x, y]) "██" else "  ")
+            }
+            append("\n")
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixBarcodePainter.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixBarcodePainter.kt
@@ -1,0 +1,88 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import io.github.alexzhirkevich.qrose.CachedPainter
+import kotlin.math.min
+
+/**
+ * Base [CachedPainter] for rendering a 2D matrix barcode.
+ */
+@Immutable
+public open class MatrixBarcodePainter(
+    public val matrix: Matrix2D,
+    public val brush: Brush = SolidColor(Color.Black),
+    public val backgroundBrush: Brush? = null,
+    public val pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    public val quietZone: Int = 0,
+) : CachedPainter() {
+
+    override val intrinsicSize: Size = Size(
+        (matrix.width + quietZone * 2) * 10f,
+        (matrix.height + quietZone * 2) * 10f
+    )
+
+    override fun DrawScope.onCache() {
+        val totalCols = matrix.width + quietZone * 2
+        val totalRows = matrix.height + quietZone * 2
+
+        val moduleWidth = size.width / totalCols
+        val moduleHeight = size.height / totalRows
+        val moduleSize = min(moduleWidth, moduleHeight)
+
+        val actualWidth = moduleSize * totalCols
+        val actualHeight = moduleSize * totalRows
+        val offsetX = (size.width - actualWidth) / 2f
+        val offsetY = (size.height - actualHeight) / 2f
+
+        if (backgroundBrush != null) {
+            drawRect(
+                brush = backgroundBrush,
+                topLeft = Offset(offsetX, offsetY),
+                size = Size(actualWidth, actualHeight)
+            )
+        }
+
+        val path = Path()
+        for (y in 0 until matrix.height) {
+            for (x in 0 until matrix.width) {
+                if (matrix[x, y]) {
+                    val px = offsetX + (x + quietZone) * moduleSize
+                    val py = offsetY + (y + quietZone) * moduleSize
+                    with(pixelShape) {
+                        path.addPixel(px, py, moduleSize, moduleSize)
+                    }
+                }
+            }
+        }
+
+        drawPath(path = path, brush = brush)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MatrixBarcodePainter) return false
+        if (matrix != other.matrix) return false
+        if (brush != other.brush) return false
+        if (backgroundBrush != other.backgroundBrush) return false
+        if (pixelShape != other.pixelShape) return false
+        if (quietZone != other.quietZone) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = matrix.hashCode()
+        result = 31 * result + brush.hashCode()
+        result = 31 * result + (backgroundBrush?.hashCode() ?: 0)
+        result = 31 * result + pixelShape.hashCode()
+        result = 31 * result + quietZone
+        return result
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixBarcodeType.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixBarcodeType.kt
@@ -1,0 +1,39 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+
+public enum class MatrixBarcodeType {
+    DataMatrix,
+    Aztec
+}
+
+/**
+ * Remember generic 2D matrix barcode painter.
+ */
+@Composable
+public fun rememberMatrixBarcodePainter(
+    data: String,
+    type: MatrixBarcodeType,
+    brush: Brush = SolidColor(Color.Black),
+    backgroundBrush: Brush? = null,
+    pixelShape: MatrixPixelShape = MatrixPixelShape.Default,
+    quietZone: Int = if (type == MatrixBarcodeType.DataMatrix) 1 else 0,
+): MatrixBarcodePainter = when (type) {
+    MatrixBarcodeType.DataMatrix -> rememberDataMatrixPainter(
+        data = data,
+        brush = brush,
+        backgroundBrush = backgroundBrush,
+        pixelShape = pixelShape,
+        quietZone = quietZone
+    )
+    MatrixBarcodeType.Aztec -> rememberAztecPainter(
+        data = data,
+        brush = brush,
+        backgroundBrush = backgroundBrush,
+        pixelShape = pixelShape,
+        quietZone = quietZone
+    )
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixPixelShape.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/MatrixPixelShape.kt
@@ -1,0 +1,52 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.Path
+
+@Immutable
+public interface MatrixPixelShape {
+
+    public fun Path.addPixel(x: Float, y: Float, width: Float, height: Float): Path
+
+    public object Default : MatrixPixelShape {
+        override fun Path.addPixel(x: Float, y: Float, width: Float, height: Float): Path = apply {
+            addRect(Rect(x, y, x + width, y + height))
+        }
+    }
+
+    @Immutable
+    public class RoundCorners(
+        public val cornerRatio: Float = 0.35f
+    ) : MatrixPixelShape {
+        override fun Path.addPixel(x: Float, y: Float, width: Float, height: Float): Path = apply {
+            val rx = width * cornerRatio.coerceIn(0f, 0.5f)
+            val ry = height * cornerRatio.coerceIn(0f, 0.5f)
+            addRoundRect(
+                RoundRect(
+                    left = x,
+                    top = y,
+                    right = x + width,
+                    bottom = y + height,
+                    radiusX = rx,
+                    radiusY = ry
+                )
+            )
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is RoundCorners) return false
+            return cornerRatio == other.cornerRatio
+        }
+
+        override fun hashCode(): Int = cornerRatio.hashCode()
+    }
+
+    public object Circle : MatrixPixelShape {
+        override fun Path.addPixel(x: Float, y: Float, width: Float, height: Float): Path = apply {
+            addOval(Rect(x, y, x + width, y + height))
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecEncoder.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecEncoder.kt
@@ -1,0 +1,329 @@
+package io.github.alexzhirkevich.qrose.matrix.aztec
+
+import io.github.alexzhirkevich.qrose.matrix.Matrix2D
+import io.github.alexzhirkevich.qrose.matrix.common.GenericGF
+import io.github.alexzhirkevich.qrose.matrix.common.ReedSolomonEncoder
+import kotlin.math.min
+
+public object AztecEncoder {
+
+    public const val DEFAULT_EC_PERCENT: Int = 33
+    public const val DEFAULT_LAYERS: Int = 0
+
+    private val NB_BITS_COMPACT = intArrayOf(0, 104, 240, 408, 608)
+    private val NB_CHUNKS_COMPACT = intArrayOf(0, 17, 40, 51, 76)
+    private val WORD_SIZE_COMPACT = intArrayOf(4, 6, 6, 8, 8)
+
+    public fun encode(
+        data: String,
+        minEccPercent: Int = DEFAULT_EC_PERCENT,
+        userSpecifiedLayers: Int = DEFAULT_LAYERS
+    ): Matrix2D {
+        val bytes = data.encodeToByteArray()
+        val bits = AztecHighLevelEncoder(bytes).encode()
+
+        // 1. Bit stuffing
+        var eccBits = (bits.size * minEccPercent / 100) + 11
+        var totalSizeBits = bits.size + eccBits
+        var layers: Int
+        var wordSize: Int
+        var totalBitsInSymbol: Int
+        var compact: Boolean
+        var stuffedBits: BooleanArrayList
+
+        if (userSpecifiedLayers != DEFAULT_LAYERS) {
+            compact = userSpecifiedLayers < 0
+            layers = kotlin.math.abs(userSpecifiedLayers)
+            if (layers > (if (compact) 4 else 32)) {
+                throw IllegalArgumentException("Illegal layers: $userSpecifiedLayers")
+            }
+            totalBitsInSymbol = totalBitsInSymbol(layers, compact)
+            wordSize = wordSize(layers, compact)
+            val usableBits = totalBitsInSymbol - (totalBitsInSymbol % wordSize)
+            stuffedBits = stuffBits(bits, wordSize)
+            if (stuffedBits.size + eccBits > usableBits) {
+                throw IllegalArgumentException("Data too large for specified status: $userSpecifiedLayers layers")
+            }
+            if (compact && stuffedBits.size > wordSize * NB_CHUNKS_COMPACT[layers]) {
+                throw IllegalArgumentException("Data too large for compact $layers layers")
+            }
+        } else {
+            wordSize = 0
+            stuffedBits = BooleanArrayList()
+            var i = 0
+            while (true) {
+                if (i > 32) {
+                    throw IllegalArgumentException("Data too large for Aztec code")
+                }
+                compact = i <= 3
+                layers = if (compact) i + 1 else i
+                totalBitsInSymbol = totalBitsInSymbol(layers, compact)
+                if (totalSizeBits > totalBitsInSymbol) {
+                    i++
+                    continue
+                }
+                if (wordSize != wordSize(layers, compact)) {
+                    wordSize = wordSize(layers, compact)
+                    stuffedBits = stuffBits(bits, wordSize)
+                }
+                val usableBits = totalBitsInSymbol - (totalBitsInSymbol % wordSize)
+                if (compact && stuffedBits.size > wordSize * NB_CHUNKS_COMPACT[layers]) {
+                    i++
+                    continue
+                }
+                if (stuffedBits.size + eccBits <= usableBits) {
+                    break
+                }
+                i++
+            }
+        }
+
+        val messageBits = generateCheckWords(stuffedBits, totalBitsInSymbol, wordSize)
+        val messageSizeInWords = stuffedBits.size / wordSize
+        val modeMessage = generateModeMessage(compact, layers, messageSizeInWords)
+
+        // Matrix drawing
+        val baseMatrixSize = if (compact) 11 + layers * 4 else 14 + layers * 4
+        val alignmentMap = IntArray(baseMatrixSize)
+        val matrixSize: Int
+
+        if (compact) {
+            matrixSize = baseMatrixSize
+            for (i in alignmentMap.indices) {
+                alignmentMap[i] = i
+            }
+        } else {
+            matrixSize = baseMatrixSize + 1 + 2 * ((baseMatrixSize / 2 - 1) / 15)
+            val origCenter = baseMatrixSize / 2
+            val center = matrixSize / 2
+            for (i in 0 until origCenter) {
+                val newOffset = i + i / 15
+                alignmentMap[origCenter - i - 1] = center - newOffset - 1
+                alignmentMap[origCenter + i] = center + newOffset + 1
+            }
+        }
+
+        val matrix = Matrix2D(matrixSize, matrixSize)
+
+        // Draw reference grid for full symbols
+        if (!compact) {
+            val center = matrixSize / 2
+            for (i in -center..center) {
+                for (j in -center..center) {
+                    if (i % 16 == 0 || j % 16 == 0) {
+                        matrix[center + i, center + j] = ((center + i) % 2 == 0) xor ((center + j) % 2 == 0)
+                    }
+                }
+            }
+        }
+
+        // Draw bullseye
+        drawBullsEye(matrix, matrixSize / 2, if (compact) 4 else 6)
+
+        // Draw mode message
+        drawModeMessage(matrix, compact, matrixSize, modeMessage, alignmentMap)
+
+        // Draw data spirals
+        drawDataSpiral(matrix, compact, layers, alignmentMap, messageBits)
+
+        return matrix
+    }
+
+    private fun totalBitsInSymbol(layers: Int, compact: Boolean): Int {
+        return if (compact) {
+            NB_BITS_COMPACT[layers]
+        } else {
+            (112 + 16 * layers) * layers
+        }
+    }
+
+    private fun wordSize(layers: Int, compact: Boolean): Int {
+        return if (compact) {
+            WORD_SIZE_COMPACT[layers]
+        } else {
+            when {
+                layers <= 2 -> 6
+                layers <= 8 -> 8
+                layers <= 16 -> 10
+                else -> 12
+            }
+        }
+    }
+
+    private fun stuffBits(bits: BooleanArrayList, wordSize: Int): BooleanArrayList {
+        val out = BooleanArrayList()
+        val n = bits.size
+        val mask = (1 shl wordSize) - 2
+        var i = 0
+        while (i < n) {
+            var value = 0
+            for (j in 0 until wordSize) {
+                if (i + j >= n || bits[i + j]) {
+                    value = value or (1 shl (wordSize - 1 - j))
+                }
+            }
+            if ((value and mask) == mask) {
+                out.appendBits(value and mask, wordSize)
+                i--
+            } else if ((value and mask) == 0) {
+                out.appendBits(value or 1, wordSize)
+                i--
+            } else {
+                out.appendBits(value, wordSize)
+            }
+            i += wordSize
+        }
+        return out
+    }
+
+    private fun generateCheckWords(stuffedBits: BooleanArrayList, totalBitsInSymbol: Int, wordSize: Int): BooleanArrayList {
+        val messageSizeInWords = stuffedBits.size / wordSize
+        val totalWords = totalBitsInSymbol / wordSize
+        val eccWords = totalWords - messageSizeInWords
+
+        val gf = when (wordSize) {
+            4 -> GenericGF.AZTEC_PARAM
+            6 -> GenericGF.AZTEC_DATA_6
+            8 -> GenericGF.AZTEC_DATA_8
+            10 -> GenericGF.AZTEC_DATA_10
+            12 -> GenericGF.AZTEC_DATA_12
+            else -> throw IllegalArgumentException("Unsupported word size: $wordSize")
+        }
+
+        val rs = ReedSolomonEncoder(gf)
+        val dataWords = IntArray(totalWords)
+        for (i in 0 until messageSizeInWords) {
+            var value = 0
+            for (j in 0 until wordSize) {
+                if (stuffedBits[i * wordSize + j]) {
+                    value = value or (1 shl (wordSize - 1 - j))
+                }
+            }
+            dataWords[i] = value
+        }
+
+        rs.encode(dataWords, eccWords)
+
+        val startPad = totalBitsInSymbol % wordSize
+        val messageBits = BooleanArrayList()
+        messageBits.appendBits(0, startPad)
+        for (word in dataWords) {
+            messageBits.appendBits(word, wordSize)
+        }
+        return messageBits
+    }
+
+    private fun generateModeMessage(compact: Boolean, layers: Int, messageSizeInWords: Int): BooleanArrayList {
+        val modeMessage = BooleanArrayList()
+        if (compact) {
+            modeMessage.appendBits(layers - 1, 2)
+            modeMessage.appendBits(messageSizeInWords - 1, 6)
+            return generateCheckWordsMode(modeMessage, 28, 4)
+        } else {
+            modeMessage.appendBits(layers - 1, 5)
+            modeMessage.appendBits(messageSizeInWords - 1, 11)
+            return generateCheckWordsMode(modeMessage, 40, 4)
+        }
+    }
+
+    private fun generateCheckWordsMode(stuffedBits: BooleanArrayList, totalBits: Int, wordSize: Int): BooleanArrayList {
+        val messageSizeInWords = stuffedBits.size / wordSize
+        val totalWords = totalBits / wordSize
+        val eccWords = totalWords - messageSizeInWords
+
+        val rs = ReedSolomonEncoder(GenericGF.AZTEC_PARAM)
+        val dataWords = IntArray(totalWords)
+        for (i in 0 until messageSizeInWords) {
+            var value = 0
+            for (j in 0 until wordSize) {
+                if (stuffedBits[i * wordSize + j]) {
+                    value = value or (1 shl (wordSize - 1 - j))
+                }
+            }
+            dataWords[i] = value
+        }
+        rs.encode(dataWords, eccWords)
+
+        val messageBits = BooleanArrayList()
+        for (word in dataWords) {
+            messageBits.appendBits(word, wordSize)
+        }
+        return messageBits
+    }
+
+    private fun drawBullsEye(matrix: Matrix2D, center: Int, size: Int) {
+        for (i in 0 until size step 2) {
+            for (j in center - i..center + i) {
+                matrix[j, center - i] = true
+                matrix[j, center + i] = true
+                matrix[center - i, j] = true
+                matrix[center + i, j] = true
+            }
+        }
+        matrix[center - size, center - size] = true
+        matrix[center - size + 1, center - size] = true
+        matrix[center - size, center - size + 1] = true
+        matrix[center + size, center - size] = true
+        matrix[center + size, center - size + 1] = true
+        matrix[center + size, center + size - 1] = true
+    }
+
+    private fun drawModeMessage(
+        matrix: Matrix2D,
+        compact: Boolean,
+        matrixSize: Int,
+        modeMessage: BooleanArrayList,
+        alignmentMap: IntArray
+    ) {
+        val center = matrixSize / 2
+        if (compact) {
+            for (i in 0 until 7) {
+                val offset = center - 3 + i
+                if (modeMessage[i]) matrix[alignmentMap[offset], alignmentMap[center - 5]] = true
+                if (modeMessage[i + 7]) matrix[alignmentMap[center + 5], alignmentMap[offset]] = true
+                if (modeMessage[i + 14]) matrix[alignmentMap[offset], alignmentMap[center + 5]] = true
+                if (modeMessage[i + 21]) matrix[alignmentMap[center - 5], alignmentMap[offset]] = true
+            }
+        } else {
+            for (i in 0 until 10) {
+                val offset = center - 5 + i + i / 5
+                if (modeMessage[i]) matrix[alignmentMap[offset], alignmentMap[center - 7]] = true
+                if (modeMessage[i + 10]) matrix[alignmentMap[center + 7], alignmentMap[offset]] = true
+                if (modeMessage[i + 20]) matrix[alignmentMap[offset], alignmentMap[center + 7]] = true
+                if (modeMessage[i + 30]) matrix[alignmentMap[center - 7], alignmentMap[offset]] = true
+            }
+        }
+    }
+
+    private fun drawDataSpiral(
+        matrix: Matrix2D,
+        compact: Boolean,
+        layers: Int,
+        alignmentMap: IntArray,
+        messageBits: BooleanArrayList
+    ) {
+        val center = alignmentMap.size / 2
+        var rowOffset = 0
+        for (i in 0 until layers) {
+            val rowSize = (layers - i) * 4 + if (compact) 9 else 12
+            for (j in 0 until rowSize) {
+                val k = j * 2
+                for (bit in 0 until 2) {
+                    if (rowOffset + k + bit < messageBits.size && messageBits[rowOffset + k + bit]) {
+                        matrix[alignmentMap[center - (layers - i) * 2 - (if (compact) 4 else 6) + bit], alignmentMap[center - (layers - i) * 2 - (if (compact) 4 else 6) + j]] = true
+                    }
+                    if (rowOffset + rowSize * 2 + k + bit < messageBits.size && messageBits[rowOffset + rowSize * 2 + k + bit]) {
+                        matrix[alignmentMap[center - (layers - i) * 2 - (if (compact) 4 else 6) + j], alignmentMap[center + (layers - i) * 2 + (if (compact) 4 else 6) - 1 - bit]] = true
+                    }
+                    if (rowOffset + rowSize * 4 + k + bit < messageBits.size && messageBits[rowOffset + rowSize * 4 + k + bit]) {
+                        matrix[alignmentMap[center + (layers - i) * 2 + (if (compact) 4 else 6) - 1 - bit], alignmentMap[center + (layers - i) * 2 + (if (compact) 4 else 6) - 1 - j]] = true
+                    }
+                    if (rowOffset + rowSize * 6 + k + bit < messageBits.size && messageBits[rowOffset + rowSize * 6 + k + bit]) {
+                        matrix[alignmentMap[center + (layers - i) * 2 + (if (compact) 4 else 6) - 1 - j], alignmentMap[center - (layers - i) * 2 - (if (compact) 4 else 6) + bit]] = true
+                    }
+                }
+            }
+            rowOffset += rowSize * 8
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecHighLevelEncoder.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecHighLevelEncoder.kt
@@ -1,0 +1,176 @@
+package io.github.alexzhirkevich.qrose.matrix.aztec
+
+internal class AztecHighLevelEncoder(private val text: ByteArray) {
+
+    fun encode(): BooleanArrayList {
+        var states: Collection<AztecState> = listOf(AztecState.INITIAL_STATE)
+        var index = 0
+        while (index < text.size) {
+            val nextChar = if (index + 1 < text.size) text[index + 1] else 0
+            val pairCode = when (text[index].toInt()) {
+                '\r'.code -> if (nextChar.toInt() == '\n'.code) 2 else 0
+                '.'.code -> if (nextChar.toInt() == ' '.code) 3 else 0
+                ','.code -> if (nextChar.toInt() == ' '.code) 4 else 0
+                ':'.code -> if (nextChar.toInt() == ' '.code) 5 else 0
+                else -> 0
+            }
+
+            states = if (pairCode > 0) {
+                updateStateListForPair(states, index, pairCode)
+            } else {
+                updateStateListForChar(states, index)
+            }
+            index += if (pairCode > 0) 2 else 1
+        }
+
+        var minState: AztecState? = null
+        for (state in states) {
+            if (minState == null || state.bitCount < minState.bitCount) {
+                minState = state
+            }
+        }
+        return minState!!.toBooleanArrayList(text)
+    }
+
+    private fun updateStateListForChar(states: Collection<AztecState>, index: Int): Collection<AztecState> {
+        val result = mutableListOf<AztecState>()
+        for (state in states) {
+            updateStateForChar(state, index, result)
+        }
+        return simplifyStates(result)
+    }
+
+    private fun updateStateForChar(state: AztecState, index: Int, result: MutableList<AztecState>) {
+        val ch = (text[index].toInt() and 0xFF).toChar()
+        val charInCurrentTable = CHAR_MAP[state.mode][ch.code] > 0
+        var stateNoBinary: AztecState? = null
+
+        for (mode in 0..4) {
+            val charInMode = CHAR_MAP[mode][ch.code]
+            if (charInMode > 0) {
+                if (stateNoBinary == null) {
+                    stateNoBinary = state.endBinaryShift(index)
+                }
+                if (!charInCurrentTable || mode == state.mode || mode == MODE_DIGIT) {
+                    val res = stateNoBinary.latchAndAppend(mode, charInMode)
+                    result.add(res)
+                }
+                if (!charInCurrentTable && SHIFT_TABLE[state.mode][mode] >= 0) {
+                    val res = stateNoBinary.shiftAndAppend(mode, charInMode)
+                    result.add(res)
+                }
+            }
+        }
+        if (state.binaryShiftByteCount > 0 || CHAR_MAP[state.mode][ch.code] == 0) {
+            val res = state.addBinaryShiftChar(index)
+            result.add(res)
+        }
+    }
+
+    private fun updateStateListForPair(states: Collection<AztecState>, index: Int, pairCode: Int): Collection<AztecState> {
+        val result = mutableListOf<AztecState>()
+        for (state in states) {
+            val stateNoBinary = state.endBinaryShift(index)
+            result.add(stateNoBinary.latchAndAppend(MODE_PUNCT, pairCode))
+            if (state.mode != MODE_PUNCT) {
+                result.add(stateNoBinary.shiftAndAppend(MODE_PUNCT, pairCode))
+            }
+            if (pairCode == 3 || pairCode == 4) {
+                val digitState = stateNoBinary
+                    .latchAndAppend(MODE_DIGIT, 16 - pairCode)
+                    .latchAndAppend(MODE_DIGIT, 1)
+                result.add(digitState)
+            }
+            if (state.binaryShiftByteCount > 0) {
+                result.add(state.addBinaryShiftChar(index).addBinaryShiftChar(index + 1))
+            }
+        }
+        return simplifyStates(result)
+    }
+
+    private fun simplifyStates(states: Iterable<AztecState>): Collection<AztecState> {
+        val result = mutableListOf<AztecState>()
+        for (newState in states) {
+            var add = true
+            val it = result.iterator()
+            while (it.hasNext()) {
+                val oldState = it.next()
+                if (oldState.isBetterThanOrEqualTo(newState)) {
+                    add = false
+                    break
+                }
+                if (newState.isBetterThanOrEqualTo(oldState)) {
+                    it.remove()
+                }
+            }
+            if (add) {
+                result.add(newState)
+            }
+        }
+        return result
+    }
+
+    companion object {
+        const val MODE_UPPER = 0
+        const val MODE_LOWER = 1
+        const val MODE_MIXED = 2
+        const val MODE_DIGIT = 3
+        const val MODE_PUNCT = 4
+
+        val LATCH_TABLE = arrayOf(
+            intArrayOf(0, (5 shl 16) + 28, (5 shl 16) + 29, (5 shl 16) + 30, (10 shl 16) + (29 shl 5) + 30),
+            intArrayOf((9 shl 16) + (30 shl 4) + 14, 0, (5 shl 16) + 29, (5 shl 16) + 30, (10 shl 16) + (29 shl 5) + 30),
+            intArrayOf((5 shl 16) + 29, (5 shl 16) + 28, 0, (5 shl 16) + 30, (5 shl 16) + 30),
+            intArrayOf((4 shl 16) + 14, (9 shl 16) + (14 shl 5) + 28, (9 shl 16) + (14 shl 5) + 29, 0, (9 shl 16) + (14 shl 5) + 30),
+            intArrayOf((5 shl 16) + 31, (10 shl 16) + (31 shl 5) + 28, (10 shl 16) + (31 shl 5) + 29, (10 shl 16) + (31 shl 5) + 30, 0)
+        )
+
+        val SHIFT_TABLE = Array(6) { IntArray(6) { -1 } }.apply {
+            this[MODE_UPPER][MODE_PUNCT] = 0
+            this[MODE_MIXED][MODE_PUNCT] = 0
+            this[MODE_LOWER][MODE_PUNCT] = 0
+            this[MODE_LOWER][MODE_UPPER] = 28
+        }
+
+        val CHAR_MAP = Array(5) { IntArray(256) }.apply {
+            this[MODE_UPPER][' '.code] = 1
+            for (c in 'A'..'Z') {
+                this[MODE_UPPER][c.code] = c - 'A' + 2
+            }
+            this[MODE_LOWER][' '.code] = 1
+            for (c in 'a'..'z') {
+                this[MODE_LOWER][c.code] = c - 'a' + 2
+            }
+            this[MODE_DIGIT][' '.code] = 1
+            for (c in '0'..'9') {
+                this[MODE_DIGIT][c.code] = c - '0' + 2
+            }
+            this[MODE_DIGIT][','.code] = 12
+            this[MODE_DIGIT]['.'.code] = 13
+
+            val mixedChars = intArrayOf(
+                0, ' '.code, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                11, 12, 13, 27, 28, 29, 30, 31, '@'.code, '\\'.code,
+                '^'.code, '_'.code, '`'.code, '|'.code, '~'.code, 127
+            )
+            for (i in mixedChars.indices) {
+                if (mixedChars[i] != 0) {
+                    this[MODE_MIXED][mixedChars[i]] = i
+                }
+            }
+
+            val punctChars = intArrayOf(
+                0, '\r'.code, 0, 0, 0, 0, '!'.code, '"'.code,
+                '#'.code, '$'.code, '%'.code, '&'.code, '\''.code, '('.code,
+                ')'.code, '*'.code, '+'.code, ','.code, '-'.code, '.'.code,
+                '/'.code, ':'.code, ';'.code, '<'.code, '='.code, '>'.code,
+                '?'.code, '['.code, ']'.code, '{'.code, '}'.code
+            )
+            for (i in punctChars.indices) {
+                if (punctChars[i] != 0) {
+                    this[MODE_PUNCT][punctChars[i]] = i
+                }
+            }
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecState.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecState.kt
@@ -1,0 +1,93 @@
+package io.github.alexzhirkevich.qrose.matrix.aztec
+
+internal class AztecState(
+    val mode: Int,
+    val token: AztecToken,
+    val binaryShiftByteCount: Int,
+    val bitCount: Int
+) {
+    companion object {
+        val INITIAL_STATE = AztecState(
+            mode = AztecHighLevelEncoder.MODE_UPPER,
+            token = AztecToken.EMPTY,
+            binaryShiftByteCount = 0,
+            bitCount = 0
+        )
+    }
+
+    fun latchAndAppend(mode: Int, value: Int): AztecState {
+        var bitCount = this.bitCount
+        var token = this.token
+        if (mode != this.mode) {
+            val latch = AztecHighLevelEncoder.LATCH_TABLE[this.mode][mode]
+            token = token.add(latch and 0xFFFF, latch shr 16)
+            bitCount += latch shr 16
+        }
+        val latchModeBitCount = if (mode == AztecHighLevelEncoder.MODE_DIGIT) 4 else 5
+        token = token.add(value, latchModeBitCount)
+        return AztecState(mode, token, 0, bitCount + latchModeBitCount)
+    }
+
+    fun shiftAndAppend(mode: Int, value: Int): AztecState {
+        val token = this.token
+        val thisModeBitCount = if (this.mode == AztecHighLevelEncoder.MODE_DIGIT) 4 else 5
+        val shiftToken = token.add(AztecHighLevelEncoder.SHIFT_TABLE[this.mode][mode], thisModeBitCount)
+        val appendedToken = shiftToken.add(value, 5)
+        return AztecState(this.mode, appendedToken, 0, this.bitCount + thisModeBitCount + 5)
+    }
+
+    fun addBinaryShiftChar(index: Int): AztecState {
+        var token = this.token
+        var mode = this.mode
+        var bitCount = this.bitCount
+        if (this.mode == AztecHighLevelEncoder.MODE_PUNCT || this.mode == AztecHighLevelEncoder.MODE_DIGIT) {
+            val latch = AztecHighLevelEncoder.LATCH_TABLE[this.mode][AztecHighLevelEncoder.MODE_UPPER]
+            token = token.add(latch and 0xFFFF, latch shr 16)
+            bitCount += latch shr 16
+            mode = AztecHighLevelEncoder.MODE_UPPER
+        }
+        val deltaBitCount = if (binaryShiftByteCount == 0 || binaryShiftByteCount == 31) 18 else if (binaryShiftByteCount == 62) 9 else 8
+        var result = AztecState(mode, token, binaryShiftByteCount + 1, bitCount + deltaBitCount)
+        if (result.binaryShiftByteCount == 2047 + 31) {
+            result = result.endBinaryShift(index + 1)
+        }
+        return result
+    }
+
+    fun endBinaryShift(index: Int): AztecState {
+        if (binaryShiftByteCount == 0) return this
+        val token = this.token.addBinaryShift(index - binaryShiftByteCount, binaryShiftByteCount)
+        return AztecState(mode, token, 0, bitCount)
+    }
+
+    fun isBetterThanOrEqualTo(other: AztecState): Boolean {
+        var mySize = this.bitCount + (AztecHighLevelEncoder.LATCH_TABLE[this.mode][other.mode] shr 16)
+        if (this.binaryShiftByteCount < other.binaryShiftByteCount) {
+            mySize += other.binaryShiftCost(other.binaryShiftByteCount) - this.binaryShiftCost(this.binaryShiftByteCount)
+        } else if (this.binaryShiftByteCount > other.binaryShiftByteCount && other.binaryShiftByteCount > 0) {
+            mySize += 10
+        }
+        return mySize <= other.bitCount
+    }
+
+    private fun binaryShiftCost(binaryShiftByteCount: Int): Int {
+        if (binaryShiftByteCount > 62) return 21
+        if (binaryShiftByteCount > 31) return 20
+        if (binaryShiftByteCount > 0) return 10
+        return 0
+    }
+
+    fun toBooleanArrayList(text: ByteArray): BooleanArrayList {
+        val symbols = mutableListOf<AztecToken>()
+        var current: AztecToken? = endBinaryShift(text.size).token
+        while (current != null) {
+            symbols.add(current)
+            current = current.previous
+        }
+        val result = BooleanArrayList()
+        for (i in symbols.size - 1 downTo 0) {
+            symbols[i].appendTo(result, text)
+        }
+        return result
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecToken.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/aztec/AztecToken.kt
@@ -1,0 +1,90 @@
+package io.github.alexzhirkevich.qrose.matrix.aztec
+
+internal abstract class AztecToken(val previous: AztecToken?) {
+
+    abstract fun appendTo(bitArray: BooleanArrayList, text: ByteArray)
+
+    fun add(value: Int, bitCount: Int): AztecToken = SimpleToken(this, value, bitCount)
+
+    fun addBinaryShift(start: Int, byteCount: Int): AztecToken = BinaryShiftToken(this, start, byteCount)
+
+    companion object {
+        val EMPTY: AztecToken = SimpleToken(null, 0, 0)
+    }
+}
+
+internal class SimpleToken(
+    previous: AztecToken?,
+    private val value: Int,
+    private val bitCount: Int
+) : AztecToken(previous) {
+
+    override fun appendTo(bitArray: BooleanArrayList, text: ByteArray) {
+        bitArray.appendBits(value, bitCount)
+    }
+
+    override fun toString(): String {
+        val v = (value and ((1 shl bitCount) - 1)) or (1 shl bitCount)
+        return "<" + v.toString(2).substring(1) + '>'
+    }
+}
+
+internal class BinaryShiftToken(
+    previous: AztecToken?,
+    private val binaryShiftStart: Int,
+    private val binaryShiftByteCount: Int
+) : AztecToken(previous) {
+
+    override fun appendTo(bitArray: BooleanArrayList, text: ByteArray) {
+        for (i in 0 until binaryShiftByteCount) {
+            if (i == 0 || (i == 31 && binaryShiftByteCount <= 62)) {
+                bitArray.appendBits(31, 5) // BINARY_SHIFT
+                if (binaryShiftByteCount > 62) {
+                    bitArray.appendBits(binaryShiftByteCount - 31, 16)
+                } else if (i == 0) {
+                    bitArray.appendBits(minOf(binaryShiftByteCount, 31), 5)
+                } else {
+                    bitArray.appendBits(binaryShiftByteCount - 31, 5)
+                }
+            }
+            bitArray.appendBits(text[binaryShiftStart + i].toInt() and 0xFF, 8)
+        }
+    }
+}
+
+internal class BooleanArrayList {
+    private var data = BooleanArray(64)
+    var size = 0
+        private set
+
+    fun appendBit(bit: Boolean) {
+        ensureCapacity(size + 1)
+        data[size++] = bit
+    }
+
+    fun appendBits(value: Int, bitCount: Int) {
+        for (i in bitCount - 1 downTo 0) {
+            appendBit(((value shr i) and 1) != 0)
+        }
+    }
+
+    operator fun get(index: Int): Boolean {
+        require(index in 0 until size)
+        return data[index]
+    }
+
+    operator fun set(index: Int, value: Boolean) {
+        require(index in 0 until size)
+        data[index] = value
+    }
+
+    fun toBooleanArray(): BooleanArray = data.copyOf(size)
+
+    private fun ensureCapacity(minCapacity: Int) {
+        if (minCapacity > data.size) {
+            var newCap = data.size * 2
+            if (newCap < minCapacity) newCap = minCapacity
+            data = data.copyOf(newCap)
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/GenericGF.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/GenericGF.kt
@@ -1,0 +1,64 @@
+package io.github.alexzhirkevich.qrose.matrix.common
+
+internal class GenericGF(
+    val primitive: Int,
+    val size: Int,
+    val generatorBase: Int
+) {
+    private val expTable = IntArray(size)
+    private val logTable = IntArray(size)
+    val zero: GenericGFPoly
+    val one: GenericGFPoly
+
+    init {
+        var x = 1
+        for (i in 0 until size) {
+            expTable[i] = x
+            x = x shl 1
+            if (x >= size) {
+                x = (x xor primitive) and (size - 1)
+            }
+        }
+        for (i in 0 until size - 1) {
+            logTable[expTable[i]] = i
+        }
+        zero = GenericGFPoly(this, intArrayOf(0))
+        one = GenericGFPoly(this, intArrayOf(1))
+    }
+
+    fun buildMonomial(degree: Int, coefficient: Int): GenericGFPoly {
+        require(degree >= 0)
+        if (coefficient == 0) return zero
+        val coefficients = IntArray(degree + 1)
+        coefficients[0] = coefficient
+        return GenericGFPoly(this, coefficients)
+    }
+
+    fun addOrSubtract(a: Int, b: Int): Int = a xor b
+
+    fun exp(a: Int): Int = expTable[a]
+
+    fun log(a: Int): Int {
+        require(a != 0) { "log(0) is undefined" }
+        return logTable[a]
+    }
+
+    fun inverse(a: Int): Int {
+        require(a != 0) { "0 has no inverse" }
+        return expTable[size - logTable[a] - 1]
+    }
+
+    fun multiply(a: Int, b: Int): Int {
+        if (a == 0 || b == 0) return 0
+        return expTable[(logTable[a] + logTable[b]) % (size - 1)]
+    }
+
+    companion object {
+        val AZTEC_DATA_12 = GenericGF(0x1069, 4096, 1)
+        val AZTEC_DATA_10 = GenericGF(0x409, 1024, 1)
+        val AZTEC_DATA_8 = GenericGF(0x12D, 256, 1)
+        val AZTEC_DATA_6 = GenericGF(0x43, 64, 1)
+        val AZTEC_PARAM = GenericGF(0x13, 16, 1)
+        val DATA_MATRIX_FIELD_256 = GenericGF(0x12D, 256, 1)
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/GenericGFPoly.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/GenericGFPoly.kt
@@ -1,0 +1,121 @@
+package io.github.alexzhirkevich.qrose.matrix.common
+
+internal class GenericGFPoly(
+    private val field: GenericGF,
+    coefficients: IntArray
+) {
+    val coefficients: IntArray
+
+    init {
+        require(coefficients.isNotEmpty())
+        if (coefficients.size > 1 && coefficients[0] == 0) {
+            var firstNonZero = 1
+            while (firstNonZero < coefficients.size && coefficients[firstNonZero] == 0) {
+                firstNonZero++
+            }
+            if (firstNonZero == coefficients.size) {
+                this.coefficients = field.zero.coefficients
+            } else {
+                val newCoefficients = IntArray(coefficients.size - firstNonZero)
+                coefficients.copyInto(newCoefficients, 0, firstNonZero, coefficients.size)
+                this.coefficients = newCoefficients
+            }
+        } else {
+            this.coefficients = coefficients
+        }
+    }
+
+    val degree: Int
+        get() = coefficients.size - 1
+
+    val isZero: Boolean
+        get() = coefficients[0] == 0
+
+    fun getCoefficient(degree: Int): Int = coefficients[coefficients.size - 1 - degree]
+
+    fun addOrSubtract(other: GenericGFPoly): GenericGFPoly {
+        if (isZero) return other
+        if (other.isZero) return this
+
+        var smallerCoefficients = this.coefficients
+        var largerCoefficients = other.coefficients
+        if (smallerCoefficients.size > largerCoefficients.size) {
+            val temp = smallerCoefficients
+            smallerCoefficients = largerCoefficients
+            largerCoefficients = temp
+        }
+
+        val sumDiff = IntArray(largerCoefficients.size)
+        val lengthDiff = largerCoefficients.size - smallerCoefficients.size
+        largerCoefficients.copyInto(sumDiff, 0, 0, lengthDiff)
+
+        for (i in lengthDiff until largerCoefficients.size) {
+            sumDiff[i] = field.addOrSubtract(smallerCoefficients[i - lengthDiff], largerCoefficients[i])
+        }
+
+        return GenericGFPoly(field, sumDiff)
+    }
+
+    fun multiply(other: GenericGFPoly): GenericGFPoly {
+        if (isZero || other.isZero) return field.zero
+
+        val aCoeff = this.coefficients
+        val aLen = aCoeff.size
+        val bCoeff = other.coefficients
+        val bLen = bCoeff.size
+        val product = IntArray(aLen + bLen - 1)
+
+        for (i in 0 until aLen) {
+            val aCoeffI = aCoeff[i]
+            for (j in 0 until bLen) {
+                product[i + j] = field.addOrSubtract(product[i + j], field.multiply(aCoeffI, bCoeff[j]))
+            }
+        }
+        return GenericGFPoly(field, product)
+    }
+
+    fun multiply(scalar: Int): GenericGFPoly {
+        if (scalar == 0) return field.zero
+        if (scalar == 1) return this
+
+        val size = coefficients.size
+        val product = IntArray(size)
+        for (i in 0 until size) {
+            product[i] = field.multiply(coefficients[i], scalar)
+        }
+        return GenericGFPoly(field, product)
+    }
+
+    fun multiplyByMonomial(degree: Int, coefficient: Int): GenericGFPoly {
+        require(degree >= 0)
+        if (coefficient == 0) return field.zero
+
+        val size = coefficients.size
+        val product = IntArray(size + degree)
+        for (i in 0 until size) {
+            product[i] = field.multiply(coefficients[i], coefficient)
+        }
+        return GenericGFPoly(field, product)
+    }
+
+    fun divide(other: GenericGFPoly): Array<GenericGFPoly> {
+        require(!other.isZero) { "Divide by 0" }
+
+        var quotient = field.zero
+        var remainder = this
+
+        val denominatorLeadingTerm = other.getCoefficient(other.degree)
+        val inverseDenominatorLeadingTerm = field.inverse(denominatorLeadingTerm)
+
+        while (remainder.degree >= other.degree && !remainder.isZero) {
+            val degreeDifference = remainder.degree - other.degree
+            val scale = field.multiply(remainder.getCoefficient(remainder.degree), inverseDenominatorLeadingTerm)
+            val term = other.multiplyByMonomial(degreeDifference, scale)
+            val iterationQuotient = field.buildMonomial(degreeDifference, scale)
+            quotient = quotient.addOrSubtract(iterationQuotient)
+            remainder = remainder.addOrSubtract(term)
+        }
+
+        return arrayOf(quotient, remainder)
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/ReedSolomonEncoder.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/common/ReedSolomonEncoder.kt
@@ -1,0 +1,43 @@
+package io.github.alexzhirkevich.qrose.matrix.common
+
+internal class ReedSolomonEncoder(private val field: GenericGF) {
+
+    private val cachedGenerators = mutableListOf<GenericGFPoly>().apply {
+        add(GenericGFPoly(field, intArrayOf(1)))
+    }
+
+    private fun buildGenerator(degree: Int): GenericGFPoly {
+        if (degree >= cachedGenerators.size) {
+            var lastGenerator = cachedGenerators.last()
+            for (d in cachedGenerators.size..degree) {
+                val nextGenerator = lastGenerator.multiply(
+                    GenericGFPoly(field, intArrayOf(1, field.exp(d - 1 + field.generatorBase)))
+                )
+                cachedGenerators.add(nextGenerator)
+                lastGenerator = nextGenerator
+            }
+        }
+        return cachedGenerators[degree]
+    }
+
+    fun encode(toEncode: IntArray, ecBytes: Int) {
+        require(ecBytes > 0) { "No error correction bytes" }
+        val dataBytes = toEncode.size - ecBytes
+        require(dataBytes > 0) { "No data bytes provided" }
+
+        val generator = buildGenerator(ecBytes)
+        val infoCoefficients = IntArray(dataBytes)
+        toEncode.copyInto(infoCoefficients, 0, 0, dataBytes)
+
+        val info = GenericGFPoly(field, infoCoefficients)
+        val shifted = info.multiplyByMonomial(ecBytes, 1)
+        val remainder = shifted.divide(generator)[1]
+        val coefficients = remainder.coefficients
+        val numZeroCoefficients = ecBytes - coefficients.size
+
+        for (i in 0 until numZeroCoefficients) {
+            toEncode[dataBytes + i] = 0
+        }
+        coefficients.copyInto(toEncode, dataBytes + numZeroCoefficients, 0, coefficients.size)
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixEncoder.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixEncoder.kt
@@ -1,0 +1,125 @@
+package io.github.alexzhirkevich.qrose.matrix.datamatrix
+
+import io.github.alexzhirkevich.qrose.matrix.Matrix2D
+import io.github.alexzhirkevich.qrose.matrix.common.GenericGF
+import io.github.alexzhirkevich.qrose.matrix.common.ReedSolomonEncoder
+
+public object DataMatrixEncoder {
+
+    public fun encode(
+        data: String,
+        shape: DataMatrixShape = DataMatrixShape.Auto
+    ): Matrix2D {
+        val (dataCodewords, symbolInfo) = HighLevelEncoder.encodeHighLevel(data, shape)
+        val allCodewords = calculateErrorCorrection(dataCodewords, symbolInfo)
+
+        val placement = DataMatrixPlacement(
+            codewords = allCodewords,
+            numcols = symbolInfo.symbolDataWidth,
+            numrows = symbolInfo.symbolDataHeight
+        )
+        placement.place()
+
+        return assembleMatrix(placement, symbolInfo)
+    }
+
+    private fun calculateErrorCorrection(
+        dataCodewords: IntArray,
+        symbolInfo: SymbolInfo
+    ): IntArray {
+        val blockCount = symbolInfo.rsBlocks
+        val rsEncoder = ReedSolomonEncoder(GenericGF.DATA_MATRIX_FIELD_256)
+
+        if (blockCount == 1) {
+            val full = IntArray(symbolInfo.totalCodewords)
+            dataCodewords.copyInto(full, 0, 0, dataCodewords.size)
+            rsEncoder.encode(full, symbolInfo.errorCodewords)
+            return full
+        }
+
+        val totalData = symbolInfo.dataCapacity
+        val totalEc = symbolInfo.errorCodewords
+        val ecPerBlock = totalEc / blockCount
+
+        val dataBlocks = Array(blockCount) { b ->
+            val len = symbolInfo.getDataLengthForInterleavedBlock(b + 1)
+            IntArray(len + ecPerBlock)
+        }
+
+        // Distribute data codewords interleaved into blocks
+        for (i in 0 until totalData) {
+            val b = i % blockCount
+            val idx = i / blockCount
+            dataBlocks[b][idx] = dataCodewords[i]
+        }
+
+        // Calculate RS for each block
+        for (b in 0 until blockCount) {
+            rsEncoder.encode(dataBlocks[b], ecPerBlock)
+        }
+
+        // Interleave output: first data codewords, then error correction codewords
+        val result = IntArray(symbolInfo.totalCodewords)
+        var outIdx = 0
+
+        for (i in 0 until totalData) {
+            result[outIdx++] = dataCodewords[i]
+        }
+
+        for (ecIdx in 0 until ecPerBlock) {
+            for (b in 0 until blockCount) {
+                val dataLen = symbolInfo.getDataLengthForInterleavedBlock(b + 1)
+                result[outIdx++] = dataBlocks[b][dataLen + ecIdx]
+            }
+        }
+
+        return result
+    }
+
+    private fun assembleMatrix(
+        placement: DataMatrixPlacement,
+        symbolInfo: SymbolInfo
+    ): Matrix2D {
+        val matrix = Matrix2D(symbolInfo.matrixWidth, symbolInfo.matrixHeight)
+        val regW = symbolInfo.dataRegionWidth
+        val regH = symbolInfo.dataRegionHeight
+
+        for (ry in 0 until symbolInfo.verticalDataRegions) {
+            for (rx in 0 until symbolInfo.horizontalDataRegions) {
+                val startX = rx * (regW + 2)
+                val startY = ry * (regH + 2)
+
+                // Left border: solid dark
+                for (dy in 0 until regH + 2) {
+                    matrix[startX, startY + dy] = true
+                }
+
+                // Bottom border: solid dark
+                for (dx in 0 until regW + 2) {
+                    matrix[startX + dx, startY + regH + 1] = true
+                }
+
+                // Top border: alternating clock track (dx % 2 == 0 is dark)
+                for (dx in 0 until regW + 2) {
+                    matrix[startX + dx, startY] = (dx % 2 == 0)
+                }
+
+                // Right border: alternating clock track (dy % 2 == 1 is dark)
+                for (dy in 0 until regH + 2) {
+                    matrix[startX + regW + 1, startY + dy] = (dy % 2 == 1)
+                }
+
+                // Internal data modules
+                for (dy in 1..regH) {
+                    for (dx in 1..regW) {
+                        val dataX = rx * regW + (dx - 1)
+                        val dataY = ry * regH + (dy - 1)
+                        matrix[startX + dx, startY + dy] = placement.getBit(dataX, dataY)
+                    }
+                }
+            }
+        }
+
+        return matrix
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixPlacement.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixPlacement.kt
@@ -1,0 +1,142 @@
+package io.github.alexzhirkevich.qrose.matrix.datamatrix
+
+internal class DataMatrixPlacement(
+    private val codewords: IntArray,
+    val numcols: Int,
+    val numrows: Int
+) {
+    // 0 = unassigned, 1 = true (dark), 2 = false (light)
+    private val array = ByteArray(numrows * numcols)
+
+    fun getBit(col: Int, row: Int): Boolean = array[row * numcols + col].toInt() == 1
+
+    private fun setBit(col: Int, row: Int, bit: Boolean) {
+        array[row * numcols + col] = (if (bit) 1 else 2).toByte()
+    }
+
+    private fun hasBit(col: Int, row: Int): Boolean = array[row * numcols + col].toInt() > 0
+
+    fun place() {
+        var pos = 0
+        var row = 4
+        var col = 0
+
+        do {
+            // Check corner 1
+            if (row == numrows && col == 0) {
+                corner1(pos++)
+            }
+            // Check corner 2
+            if (row == numrows - 2 && col == 0 && numcols % 4 != 0) {
+                corner2(pos++)
+            }
+            // Check corner 3
+            if (row == numrows - 2 && col == 0 && numcols % 8 == 4) {
+                corner3(pos++)
+            }
+            // Check corner 4
+            if (row == numrows + 4 && col == 2 && numcols % 8 == 0) {
+                corner4(pos++)
+            }
+
+            // Up-right scan
+            do {
+                if (row < numrows && col >= 0 && !hasBit(col, row)) {
+                    utah(row, col, pos++)
+                }
+                row -= 2
+                col += 2
+            } while (row >= 0 && col < numcols)
+            row += 1
+            col += 3
+
+            // Down-left scan
+            do {
+                if (row >= 0 && col < numcols && !hasBit(col, row)) {
+                    utah(row, col, pos++)
+                }
+                row += 2
+                col -= 2
+            } while (row < numrows && col >= 0)
+            row += 3
+            col += 1
+        } while (row < numrows || col < numcols)
+
+        // Point in lower right may not be set
+        if (!hasBit(numcols - 1, numrows - 1)) {
+            setBit(numcols - 1, numrows - 1, true)
+            setBit(numcols - 2, numrows - 2, true)
+        }
+    }
+
+    private fun module(row: Int, col: Int, pos: Int, bit: Int) {
+        var r = row
+        var c = col
+        if (r < 0) {
+            r += numrows
+            c += 4 - ((numrows + 4) % 8)
+        }
+        if (c < 0) {
+            c += numcols
+            r += 4 - ((numcols + 4) % 8)
+        }
+        val v = codewords[pos]
+        val isDark = (v and (1 shl (8 - bit))) != 0
+        setBit(c, r, isDark)
+    }
+
+    private fun utah(row: Int, col: Int, pos: Int) {
+        module(row - 2, col - 2, pos, 1)
+        module(row - 2, col - 1, pos, 2)
+        module(row - 1, col - 2, pos, 3)
+        module(row - 1, col - 1, pos, 4)
+        module(row - 1, col, pos, 5)
+        module(row, col - 2, pos, 6)
+        module(row, col - 1, pos, 7)
+        module(row, col, pos, 8)
+    }
+
+    private fun corner1(pos: Int) {
+        module(numrows - 1, 0, pos, 1)
+        module(numrows - 1, 1, pos, 2)
+        module(numrows - 1, 2, pos, 3)
+        module(0, numcols - 2, pos, 4)
+        module(0, numcols - 1, pos, 5)
+        module(1, numcols - 1, pos, 6)
+        module(2, numcols - 1, pos, 7)
+        module(3, numcols - 1, pos, 8)
+    }
+
+    private fun corner2(pos: Int) {
+        module(numrows - 3, 0, pos, 1)
+        module(numrows - 2, 0, pos, 2)
+        module(numrows - 1, 0, pos, 3)
+        module(0, numcols - 4, pos, 4)
+        module(0, numcols - 3, pos, 5)
+        module(0, numcols - 2, pos, 6)
+        module(0, numcols - 1, pos, 7)
+        module(1, numcols - 1, pos, 8)
+    }
+
+    private fun corner3(pos: Int) {
+        module(numrows - 3, 0, pos, 1)
+        module(numrows - 2, 0, pos, 2)
+        module(numrows - 1, 0, pos, 3)
+        module(0, numcols - 2, pos, 4)
+        module(0, numcols - 1, pos, 5)
+        module(1, numcols - 1, pos, 6)
+        module(2, numcols - 1, pos, 7)
+        module(3, numcols - 1, pos, 8)
+    }
+
+    private fun corner4(pos: Int) {
+        module(numrows - 1, 0, pos, 1)
+        module(numrows - 1, numcols - 1, pos, 2)
+        module(0, numcols - 3, pos, 3)
+        module(0, numcols - 2, pos, 4)
+        module(0, numcols - 1, pos, 5)
+        module(1, numcols - 3, pos, 6)
+        module(1, numcols - 2, pos, 7)
+        module(1, numcols - 1, pos, 8)
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixShape.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/DataMatrixShape.kt
@@ -1,0 +1,21 @@
+package io.github.alexzhirkevich.qrose.matrix.datamatrix
+
+/**
+ * Desired shape format for Data Matrix symbols.
+ */
+public enum class DataMatrixShape {
+    /**
+     * Choose the smallest symbol, preferring square over rectangular if both fit.
+     */
+    Auto,
+
+    /**
+     * Force square symbol shape.
+     */
+    Square,
+
+    /**
+     * Force rectangular symbol shape.
+     */
+    Rectangle
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/HighLevelEncoder.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/HighLevelEncoder.kt
@@ -1,0 +1,513 @@
+package io.github.alexzhirkevich.qrose.matrix.datamatrix
+
+import kotlin.math.ceil
+import kotlin.math.min
+
+internal object HighLevelEncoder {
+
+    const val ASCII_ENCODATION = 0
+    const val C40_ENCODATION = 1
+    const val TEXT_ENCODATION = 2
+    const val X12_ENCODATION = 3
+    const val EDIFACT_ENCODATION = 4
+    const val BASE256_ENCODATION = 5
+
+    private const val PAD = 129
+    private const val LATCH_TO_C40 = 230
+    private const val LATCH_TO_BASE256 = 231
+    private const val UPPER_SHIFT = 235
+    private const val LATCH_TO_ANSIX12 = 238
+    private const val LATCH_TO_TEXT = 239
+    private const val LATCH_TO_EDIFACT = 240
+    private const val C40_UNLATCH = 254
+    private const val X12_UNLATCH = 254
+
+    fun encodeHighLevel(msg: String, shape: DataMatrixShape): Pair<IntArray, SymbolInfo> {
+        val context = EncoderContext(msg, shape)
+
+        while (context.hasMoreCharacters()) {
+            when (context.encodingMode) {
+                ASCII_ENCODATION -> encodeAscii(context)
+                C40_ENCODATION -> encodeC40(context)
+                TEXT_ENCODATION -> encodeText(context)
+                X12_ENCODATION -> encodeX12(context)
+                EDIFACT_ENCODATION -> encodeEdifact(context)
+                BASE256_ENCODATION -> encodeBase256(context)
+                else -> throw IllegalStateException("Unknown mode: ${context.encodingMode}")
+            }
+        }
+
+        val len = context.codewords.size
+        context.updateSymbolInfo()
+        val capacity = context.symbolInfo!!.dataCapacity
+        if (len < capacity) {
+            context.writeCodeword(PAD)
+        }
+        while (context.codewords.size < capacity) {
+            val pad = randomize253State(PAD, context.codewords.size + 1)
+            context.writeCodeword(pad)
+        }
+
+        return context.codewords.toIntArray() to context.symbolInfo!!
+    }
+
+    private fun randomize253State(codewordValue: Int, codewordPosition: Int): Int {
+        val pseudoRandom = ((149 * codewordPosition) % 253) + 1
+        val temp = codewordValue + pseudoRandom
+        return if (temp <= 254) temp else temp - 254
+    }
+
+    private fun randomize255State(codewordValue: Int, codewordPosition: Int): Int {
+        val pseudoRandom = ((149 * codewordPosition) % 255) + 1
+        val temp = codewordValue + pseudoRandom
+        return if (temp <= 255) temp else temp - 256
+    }
+
+    private fun encodeAscii(context: EncoderContext) {
+        val n = lookAheadTest(context.msg, context.pos, ASCII_ENCODATION)
+        if (n != ASCII_ENCODATION) {
+            when (n) {
+                C40_ENCODATION -> {
+                    context.writeCodeword(LATCH_TO_C40)
+                    context.encodingMode = C40_ENCODATION
+                }
+                TEXT_ENCODATION -> {
+                    context.writeCodeword(LATCH_TO_TEXT)
+                    context.encodingMode = TEXT_ENCODATION
+                }
+                X12_ENCODATION -> {
+                    context.writeCodeword(LATCH_TO_ANSIX12)
+                    context.encodingMode = X12_ENCODATION
+                }
+                EDIFACT_ENCODATION -> {
+                    context.writeCodeword(LATCH_TO_EDIFACT)
+                    context.encodingMode = EDIFACT_ENCODATION
+                }
+                BASE256_ENCODATION -> {
+                    context.writeCodeword(LATCH_TO_BASE256)
+                    context.encodingMode = BASE256_ENCODATION
+                }
+                else -> error("Illegal mode $n")
+            }
+        } else {
+            val c = context.currentChar
+            if (isDigit(c) && context.hasDigitAt(context.pos + 1)) {
+                val d2 = context.msg[context.pos + 1]
+                val num = (c - '0') * 10 + (d2 - '0')
+                context.writeCodeword(num + 130)
+                context.pos += 2
+            } else {
+                if (c.code in 1..127) {
+                    context.writeCodeword(c.code + 1)
+                    context.pos++
+                } else if (c.code > 127) {
+                    context.writeCodeword(UPPER_SHIFT)
+                    context.writeCodeword((c.code - 128) + 1)
+                    context.pos++
+                } else {
+                    context.writeCodeword(c.code + 1)
+                    context.pos++
+                }
+            }
+        }
+    }
+
+    private fun encodeC40(context: EncoderContext) {
+        val buffer = StringBuilder()
+        while (context.hasMoreCharacters()) {
+            val c = context.currentChar
+            context.pos++
+            val lastChar = !context.hasMoreCharacters()
+            encodeC40Char(c, buffer)
+
+            val count = (buffer.length / 3) * 2
+            context.updateSymbolInfo(context.codewords.size + count)
+            val available = context.symbolInfo!!.dataCapacity - context.codewords.size
+
+            if (lastChar) {
+                writeC40Buffer(context, buffer)
+                return
+            }
+
+            if (buffer.length % 3 == 0) {
+                val newMode = lookAheadTest(context.msg, context.pos, C40_ENCODATION)
+                if (newMode != C40_ENCODATION) {
+                    context.writeCodeword(C40_UNLATCH)
+                    context.encodingMode = ASCII_ENCODATION
+                    writeC40Buffer(context, buffer)
+                    return
+                }
+            }
+        }
+        writeC40Buffer(context, buffer)
+    }
+
+    private fun encodeC40Char(c: Char, buffer: StringBuilder) {
+        when {
+            c == ' ' -> buffer.append(3.toChar())
+            c in '0'..'9' -> buffer.append((c - '0' + 4).toChar())
+            c in 'A'..'Z' -> buffer.append((c - 'A' + 14).toChar())
+            c.code < 32 -> {
+                buffer.append(0.toChar())
+                buffer.append(c)
+            }
+            c.code in 33..47 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 33).toChar())
+            }
+            c.code in 58..64 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 58 + 15).toChar())
+            }
+            c.code in 91..95 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 91 + 22).toChar())
+            }
+            c.code in 96..127 -> {
+                buffer.append(2.toChar())
+                buffer.append((c.code - 96).toChar())
+            }
+            else -> {
+                buffer.append(1.toChar())
+                buffer.append(0x1E.toChar())
+                encodeC40Char((c.code - 128).toChar(), buffer)
+            }
+        }
+    }
+
+    private fun writeC40Buffer(context: EncoderContext, buffer: StringBuilder) {
+        var idx = 0
+        while (idx + 3 <= buffer.length) {
+            val v1 = buffer[idx].code
+            val v2 = buffer[idx + 1].code
+            val v3 = buffer[idx + 2].code
+            val value = 1600 * v1 + 40 * v2 + v3 + 1
+            context.writeCodeword(value / 256)
+            context.writeCodeword(value % 256)
+            idx += 3
+        }
+        val rest = buffer.length - idx
+        if (rest > 0) {
+            if (context.encodingMode != ASCII_ENCODATION) {
+                context.writeCodeword(C40_UNLATCH)
+                context.encodingMode = ASCII_ENCODATION
+            }
+            context.pos -= rest
+        }
+    }
+
+    private fun encodeText(context: EncoderContext) {
+        val buffer = StringBuilder()
+        while (context.hasMoreCharacters()) {
+            val c = context.currentChar
+            context.pos++
+            val lastChar = !context.hasMoreCharacters()
+            encodeTextChar(c, buffer)
+
+            val count = (buffer.length / 3) * 2
+            context.updateSymbolInfo(context.codewords.size + count)
+
+            if (lastChar) {
+                writeTextBuffer(context, buffer)
+                return
+            }
+
+            if (buffer.length % 3 == 0) {
+                val newMode = lookAheadTest(context.msg, context.pos, TEXT_ENCODATION)
+                if (newMode != TEXT_ENCODATION) {
+                    context.writeCodeword(C40_UNLATCH)
+                    context.encodingMode = ASCII_ENCODATION
+                    writeTextBuffer(context, buffer)
+                    return
+                }
+            }
+        }
+        writeTextBuffer(context, buffer)
+    }
+
+    private fun encodeTextChar(c: Char, buffer: StringBuilder) {
+        when {
+            c == ' ' -> buffer.append(3.toChar())
+            c in '0'..'9' -> buffer.append((c - '0' + 4).toChar())
+            c in 'a'..'z' -> buffer.append((c - 'a' + 14).toChar())
+            c.code < 32 -> {
+                buffer.append(0.toChar())
+                buffer.append(c)
+            }
+            c.code in 33..47 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 33).toChar())
+            }
+            c.code in 58..64 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 58 + 15).toChar())
+            }
+            c.code in 91..95 -> {
+                buffer.append(1.toChar())
+                buffer.append((c.code - 91 + 22).toChar())
+            }
+            c in 'A'..'Z' -> {
+                buffer.append(2.toChar())
+                buffer.append((c - 'A').toChar())
+            }
+            c.code in 123..127 -> {
+                buffer.append(2.toChar())
+                buffer.append((c.code - 123 + 27).toChar())
+            }
+            else -> {
+                buffer.append(1.toChar())
+                buffer.append(0x1E.toChar())
+                encodeTextChar((c.code - 128).toChar(), buffer)
+            }
+        }
+    }
+
+    private fun writeTextBuffer(context: EncoderContext, buffer: StringBuilder) {
+        var idx = 0
+        while (idx + 3 <= buffer.length) {
+            val v1 = buffer[idx].code
+            val v2 = buffer[idx + 1].code
+            val v3 = buffer[idx + 2].code
+            val value = 1600 * v1 + 40 * v2 + v3 + 1
+            context.writeCodeword(value / 256)
+            context.writeCodeword(value % 256)
+            idx += 3
+        }
+        val rest = buffer.length - idx
+        if (rest > 0) {
+            if (context.encodingMode != ASCII_ENCODATION) {
+                context.writeCodeword(C40_UNLATCH)
+                context.encodingMode = ASCII_ENCODATION
+            }
+            context.pos -= rest
+        }
+    }
+
+    private fun encodeX12(context: EncoderContext) {
+        val buffer = StringBuilder()
+        while (context.hasMoreCharacters()) {
+            val c = context.currentChar
+            context.pos++
+            encodeX12Char(c, buffer)
+            if (buffer.length % 3 == 0) {
+                var idx = 0
+                while (idx + 3 <= buffer.length) {
+                    val v1 = buffer[idx].code
+                    val v2 = buffer[idx + 1].code
+                    val v3 = buffer[idx + 2].code
+                    val value = 1600 * v1 + 40 * v2 + v3 + 1
+                    context.writeCodeword(value / 256)
+                    context.writeCodeword(value % 256)
+                    idx += 3
+                }
+                buffer.clear()
+                val newMode = lookAheadTest(context.msg, context.pos, X12_ENCODATION)
+                if (newMode != X12_ENCODATION) {
+                    context.writeCodeword(X12_UNLATCH)
+                    context.encodingMode = ASCII_ENCODATION
+                    return
+                }
+            }
+        }
+        if (buffer.isNotEmpty()) {
+            context.writeCodeword(X12_UNLATCH)
+            context.encodingMode = ASCII_ENCODATION
+            context.pos -= buffer.length
+        }
+    }
+
+    private fun encodeX12Char(c: Char, buffer: StringBuilder) {
+        when {
+            c == '\r' -> buffer.append(0.toChar())
+            c == '*' -> buffer.append(1.toChar())
+            c == '>' -> buffer.append(2.toChar())
+            c == ' ' -> buffer.append(3.toChar())
+            c in '0'..'9' -> buffer.append((c - '0' + 4).toChar())
+            c in 'A'..'Z' -> buffer.append((c - 'A' + 14).toChar())
+            else -> throw IllegalArgumentException("Illegal character in X12: $c")
+        }
+    }
+
+    private fun encodeEdifact(context: EncoderContext) {
+        val buffer = StringBuilder()
+        while (context.hasMoreCharacters()) {
+            val c = context.currentChar
+            if (c.code in 32..94) {
+                buffer.append((c.code - 32).toChar())
+                context.pos++
+            } else {
+                break
+            }
+            if (buffer.length == 4) {
+                writeEdifactBlock(context, buffer)
+                buffer.clear()
+                val newMode = lookAheadTest(context.msg, context.pos, EDIFACT_ENCODATION)
+                if (newMode != EDIFACT_ENCODATION) {
+                    context.encodingMode = ASCII_ENCODATION
+                    break
+                }
+            }
+        }
+        if (buffer.isNotEmpty()) {
+            buffer.append(31.toChar()) // Unlatch
+            while (buffer.length < 4) {
+                buffer.append(0.toChar())
+            }
+            writeEdifactBlock(context, buffer)
+            context.encodingMode = ASCII_ENCODATION
+        } else if (context.encodingMode == EDIFACT_ENCODATION) {
+            context.writeCodeword(0x1F) // unlatch
+            context.encodingMode = ASCII_ENCODATION
+        }
+    }
+
+    private fun writeEdifactBlock(context: EncoderContext, buffer: StringBuilder) {
+        val v1 = buffer[0].code
+        val v2 = buffer[1].code
+        val v3 = buffer[2].code
+        val v4 = buffer[3].code
+        val value = (v1 shl 18) or (v2 shl 12) or (v3 shl 6) or v4
+        context.writeCodeword((value shr 16) and 0xFF)
+        context.writeCodeword((value shr 8) and 0xFF)
+        context.writeCodeword(value and 0xFF)
+    }
+
+    private fun encodeBase256(context: EncoderContext) {
+        val buffer = mutableListOf<Int>()
+        buffer.add(0) // placeholder for length
+        while (context.hasMoreCharacters()) {
+            val c = context.currentChar
+            buffer.add(c.code and 0xFF)
+            context.pos++
+            val newMode = lookAheadTest(context.msg, context.pos, BASE256_ENCODATION)
+            if (newMode != BASE256_ENCODATION) {
+                context.encodingMode = ASCII_ENCODATION
+                break
+            }
+        }
+        val dataCount = buffer.size - 1
+        var lengthFieldSize = 1
+        if (dataCount > 249) {
+            lengthFieldSize = 2
+            buffer[0] = (dataCount / 250 + 249)
+            buffer.add(1, dataCount % 250)
+        } else {
+            buffer[0] = dataCount
+        }
+
+        for (i in 0 until buffer.size) {
+            val cw = randomize255State(buffer[i], context.codewords.size + 1)
+            context.writeCodeword(cw)
+        }
+    }
+
+    private fun lookAheadTest(msg: String, startpos: Int, currentMode: Int): Int {
+        if (startpos >= msg.length) return currentMode
+
+        var charCounts = floatArrayOf(0f, 1f, 1f, 1f, 1f, 1.25f)
+        when (currentMode) {
+            C40_ENCODATION -> charCounts[C40_ENCODATION] = 0f
+            TEXT_ENCODATION -> charCounts[TEXT_ENCODATION] = 0f
+            X12_ENCODATION -> charCounts[X12_ENCODATION] = 0f
+            EDIFACT_ENCODATION -> charCounts[EDIFACT_ENCODATION] = 0f
+            BASE256_ENCODATION -> charCounts[BASE256_ENCODATION] = 0f
+        }
+
+        var charsScanned = 0
+        while (startpos + charsScanned < msg.length) {
+            val c = msg[startpos + charsScanned]
+            charsScanned++
+
+            // ASCII
+            if (isDigit(c)) {
+                charCounts[ASCII_ENCODATION] += 0.5f
+            } else if (c.code > 127) {
+                charCounts[ASCII_ENCODATION] = ceil(charCounts[ASCII_ENCODATION]) + 2f
+            } else {
+                charCounts[ASCII_ENCODATION] = ceil(charCounts[ASCII_ENCODATION]) + 1f
+            }
+
+            // C40
+            if (c in '0'..'9' || c in 'A'..'Z' || c == ' ') {
+                charCounts[C40_ENCODATION] += 2f / 3f
+            } else if (c.code > 127) {
+                charCounts[C40_ENCODATION] += 8f / 3f
+            } else {
+                charCounts[C40_ENCODATION] += 4f / 3f
+            }
+
+            // TEXT
+            if (c in '0'..'9' || c in 'a'..'z' || c == ' ') {
+                charCounts[TEXT_ENCODATION] += 2f / 3f
+            } else if (c.code > 127) {
+                charCounts[TEXT_ENCODATION] += 8f / 3f
+            } else {
+                charCounts[TEXT_ENCODATION] += 4f / 3f
+            }
+
+            // X12
+            if (c in '0'..'9' || c in 'A'..'Z' || c == ' ' || c == '\r' || c == '*' || c == '>') {
+                charCounts[X12_ENCODATION] += 2f / 3f
+            } else {
+                charCounts[X12_ENCODATION] = Float.MAX_VALUE / 2
+            }
+
+            // EDIFACT
+            if (c.code in 32..94) {
+                charCounts[EDIFACT_ENCODATION] += 3f / 4f
+            } else {
+                charCounts[EDIFACT_ENCODATION] = Float.MAX_VALUE / 2
+            }
+
+            // BASE256
+            charCounts[BASE256_ENCODATION] += 1f
+
+            if (charsScanned >= 4) {
+                val minCount = charCounts.minOrNull() ?: Float.MAX_VALUE
+                if (charCounts[ASCII_ENCODATION] == minCount) return ASCII_ENCODATION
+                if (charCounts[BASE256_ENCODATION] == minCount) return BASE256_ENCODATION
+                if (charCounts[EDIFACT_ENCODATION] == minCount) return EDIFACT_ENCODATION
+                if (charCounts[TEXT_ENCODATION] == minCount) return TEXT_ENCODATION
+                if (charCounts[X12_ENCODATION] == minCount) return X12_ENCODATION
+                if (charCounts[C40_ENCODATION] == minCount) return C40_ENCODATION
+            }
+        }
+
+        val minCount = charCounts.minOrNull() ?: Float.MAX_VALUE
+        if (charCounts[ASCII_ENCODATION] == minCount) return ASCII_ENCODATION
+        if (charCounts[BASE256_ENCODATION] == minCount) return BASE256_ENCODATION
+        if (charCounts[EDIFACT_ENCODATION] == minCount) return EDIFACT_ENCODATION
+        if (charCounts[TEXT_ENCODATION] == minCount) return TEXT_ENCODATION
+        if (charCounts[X12_ENCODATION] == minCount) return X12_ENCODATION
+        return C40_ENCODATION
+    }
+
+    private fun isDigit(c: Char): Boolean = c in '0'..'9'
+
+    internal class EncoderContext(
+        val msg: String,
+        val shape: DataMatrixShape
+    ) {
+        var pos = 0
+        var encodingMode = ASCII_ENCODATION
+        val codewords = mutableListOf<Int>()
+        var symbolInfo: SymbolInfo? = null
+
+        val currentChar: Char
+            get() = msg[pos]
+
+        fun hasMoreCharacters(): Boolean = pos < msg.length
+
+        fun hasDigitAt(index: Int): Boolean = index < msg.length && isDigit(msg[index])
+
+        fun writeCodeword(cw: Int) {
+            codewords.add(cw)
+        }
+
+        fun updateSymbolInfo(len: Int = codewords.size) {
+            if (symbolInfo == null || len > symbolInfo!!.dataCapacity) {
+                symbolInfo = SymbolInfo.lookup(len, shape)
+            }
+        }
+    }
+}

--- a/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/SymbolInfo.kt
+++ b/qrose-matrix/src/commonMain/kotlin/io/github/alexzhirkevich/qrose/matrix/datamatrix/SymbolInfo.kt
@@ -1,0 +1,88 @@
+package io.github.alexzhirkevich.qrose.matrix.datamatrix
+
+internal class SymbolInfo(
+    val rectangular: Boolean,
+    val dataCapacity: Int,
+    val errorCodewords: Int,
+    val matrixWidth: Int,
+    val matrixHeight: Int,
+    val dataRegionWidth: Int,
+    val dataRegionHeight: Int,
+    val rsBlocks: Int = 1,
+) {
+    val symbolDataWidth: Int
+        get() = (matrixWidth / (dataRegionWidth + 2)) * dataRegionWidth
+
+    val symbolDataHeight: Int
+        get() = (matrixHeight / (dataRegionHeight + 2)) * dataRegionHeight
+
+    val horizontalDataRegions: Int
+        get() = matrixWidth / (dataRegionWidth + 2)
+
+    val verticalDataRegions: Int
+        get() = matrixHeight / (dataRegionHeight + 2)
+
+    val totalCodewords: Int
+        get() = dataCapacity + errorCodewords
+
+    fun getDataLengthForInterleavedBlock(index: Int): Int {
+        val base = dataCapacity / rsBlocks
+        val remainder = dataCapacity % rsBlocks
+        return if (index <= remainder) base + 1 else base
+    }
+
+    fun getErrorLengthForInterleavedBlock(): Int {
+        return errorCodewords / rsBlocks
+    }
+
+    companion object {
+        private val SYMBOLS = arrayOf(
+            // 24 Square symbols
+            SymbolInfo(false, 3, 5, 10, 10, 8, 8),
+            SymbolInfo(false, 5, 7, 12, 12, 10, 10),
+            SymbolInfo(false, 8, 10, 14, 14, 12, 12),
+            SymbolInfo(false, 12, 12, 16, 16, 14, 14),
+            SymbolInfo(false, 18, 14, 18, 18, 16, 16),
+            SymbolInfo(false, 22, 18, 20, 20, 18, 18),
+            SymbolInfo(false, 30, 20, 22, 22, 20, 20),
+            SymbolInfo(false, 36, 24, 24, 24, 22, 22),
+            SymbolInfo(false, 44, 28, 26, 26, 24, 24),
+            SymbolInfo(false, 62, 36, 32, 32, 14, 14),
+            SymbolInfo(false, 86, 42, 36, 36, 16, 16),
+            SymbolInfo(false, 114, 48, 40, 40, 18, 18),
+            SymbolInfo(false, 144, 56, 44, 44, 20, 20),
+            SymbolInfo(false, 174, 68, 48, 48, 22, 22),
+            SymbolInfo(false, 204, 84, 52, 52, 24, 24, 2),
+            SymbolInfo(false, 280, 112, 64, 64, 14, 14, 2),
+            SymbolInfo(false, 368, 144, 72, 72, 16, 16, 4),
+            SymbolInfo(false, 456, 192, 80, 80, 18, 18, 4),
+            SymbolInfo(false, 576, 224, 88, 88, 20, 20, 4),
+            SymbolInfo(false, 696, 272, 96, 96, 22, 22, 4),
+            SymbolInfo(false, 816, 336, 104, 104, 24, 24, 6),
+            SymbolInfo(false, 1050, 408, 120, 120, 18, 18, 6),
+            SymbolInfo(false, 1304, 496, 132, 132, 20, 20, 8),
+            SymbolInfo(false, 1558, 620, 144, 144, 22, 22, 10),
+
+            // 6 Rectangular symbols
+            SymbolInfo(true, 5, 7, 18, 8, 16, 6),
+            SymbolInfo(true, 10, 11, 32, 8, 14, 6),
+            SymbolInfo(true, 16, 14, 26, 12, 24, 10),
+            SymbolInfo(true, 22, 18, 36, 12, 16, 10),
+            SymbolInfo(true, 32, 24, 36, 16, 16, 12),
+            SymbolInfo(true, 49, 28, 48, 16, 22, 12)
+        )
+
+        fun lookup(dataCodewords: Int, shape: DataMatrixShape): SymbolInfo {
+            for (symbol in SYMBOLS) {
+                if (shape == DataMatrixShape.Square && symbol.rectangular) continue
+                if (shape == DataMatrixShape.Rectangle && !symbol.rectangular) continue
+                if (dataCodewords <= symbol.dataCapacity) {
+                    return symbol
+                }
+            }
+            throw IllegalArgumentException(
+                "Can't find a symbol arrangement that matches the query. Data codewords: $dataCodewords, shape: $shape"
+            )
+        }
+    }
+}

--- a/qrose-matrix/src/commonTest/kotlin/io/github/alexzhirkevich/qrose/matrix/AztecEncoderTest.kt
+++ b/qrose-matrix/src/commonTest/kotlin/io/github/alexzhirkevich/qrose/matrix/AztecEncoderTest.kt
@@ -1,0 +1,44 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import io.github.alexzhirkevich.qrose.matrix.aztec.AztecEncoder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AztecEncoderTest {
+
+    @Test
+    fun testCompactAztecCode() {
+        val matrix = AztecEncoder.encode("Aztec")
+        assertEquals(matrix.width, matrix.height)
+
+        val center = matrix.width / 2
+
+        // Center must be dark
+        assertTrue(matrix[center, center], "Center module must be dark")
+
+        // Ring 1 (distance 1 from center) must be light (except possible corner orientation bits)
+        assertFalse(matrix[center - 1, center], "Ring 1 top must be light")
+        assertFalse(matrix[center + 1, center], "Ring 1 bottom must be light")
+        assertFalse(matrix[center, center - 1], "Ring 1 left must be light")
+        assertFalse(matrix[center, center + 1], "Ring 1 right must be light")
+
+        // Ring 2 (distance 2 from center) must be dark
+        assertTrue(matrix[center - 2, center], "Ring 2 top must be dark")
+        assertTrue(matrix[center + 2, center], "Ring 2 bottom must be dark")
+        assertTrue(matrix[center, center - 2], "Ring 2 left must be dark")
+        assertTrue(matrix[center, center + 2], "Ring 2 right must be dark")
+    }
+
+    @Test
+    fun testLongTextAztecCode() {
+        val text = "Aztec Code 2D matrix barcode specification ISO/IEC 24778 testing long string data payload."
+        val matrix = AztecEncoder.encode(text)
+        assertEquals(matrix.width, matrix.height)
+        assertTrue(matrix.width >= 23)
+
+        val center = matrix.width / 2
+        assertTrue(matrix[center, center], "Bullseye center must be dark")
+    }
+}

--- a/qrose-matrix/src/commonTest/kotlin/io/github/alexzhirkevich/qrose/matrix/DataMatrixEncoderTest.kt
+++ b/qrose-matrix/src/commonTest/kotlin/io/github/alexzhirkevich/qrose/matrix/DataMatrixEncoderTest.kt
@@ -1,0 +1,72 @@
+package io.github.alexzhirkevich.qrose.matrix
+
+import io.github.alexzhirkevich.qrose.matrix.datamatrix.DataMatrixEncoder
+import io.github.alexzhirkevich.qrose.matrix.datamatrix.DataMatrixShape
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataMatrixEncoderTest {
+
+    @Test
+    fun testSmallSquareDataMatrix() {
+        val matrix = DataMatrixEncoder.encode("Test", DataMatrixShape.Square)
+        assertEquals(matrix.width, matrix.height)
+        assertTrue(matrix.width >= 10)
+
+        // Left border must be solid dark
+        for (y in 0 until matrix.height) {
+            assertTrue(matrix[0, y], "Left border at y=$y must be dark")
+        }
+
+        // Bottom border must be solid dark
+        for (x in 0 until matrix.width) {
+            assertTrue(matrix[x, matrix.height - 1], "Bottom border at x=$x must be dark")
+        }
+
+        // Top border must alternate: x % 2 == 0 is dark
+        for (x in 0 until matrix.width) {
+            assertEquals(x % 2 == 0, matrix[x, 0], "Top clock track at x=$x")
+        }
+
+        // Right border must alternate: y % 2 == 1 is dark
+        for (y in 0 until matrix.height) {
+            assertEquals(y % 2 == 1, matrix[matrix.width - 1, y], "Right clock track at y=$y")
+        }
+    }
+
+    @Test
+    fun testRectangularDataMatrix() {
+        val matrix = DataMatrixEncoder.encode("TEST1234", DataMatrixShape.Rectangle)
+        assertTrue(matrix.width > matrix.height, "Rectangular matrix width (${matrix.width}) must exceed height (${matrix.height})")
+
+        // Left border of first region is solid dark
+        for (y in 0 until matrix.height) {
+            assertTrue(matrix[0, y], "Left border at y=$y must be dark")
+        }
+
+        // Bottom border is solid dark
+        for (x in 0 until matrix.width) {
+            // Note: each region has bottom solid dark
+            if (x < matrix.width) {
+                // at bottom of matrix
+                assertTrue(matrix[x, matrix.height - 1], "Bottom border at x=$x must be dark")
+            }
+        }
+    }
+
+    @Test
+    fun testDigitsDataMatrix() {
+        val matrix = DataMatrixEncoder.encode("01234567890123456789")
+        assertTrue(matrix.width >= 14)
+        assertTrue(matrix.height >= 14)
+    }
+
+    @Test
+    fun testLongTextMultiRegionDataMatrix() {
+        val text = "Compose Multiplatform Data Matrix encoding supporting ISO/IEC 16022 standard!"
+        val matrix = DataMatrixEncoder.encode(text, DataMatrixShape.Square)
+        assertTrue(matrix.width >= 32)
+        assertEquals(matrix.width, matrix.height)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ rootProject.name = "QRose"
 include(":qrose")
 include(":qrose-core")
 include(":qrose-oned")
+include(":qrose-matrix")
 //include(":qrose-scanner")
 
 include(":example:desktopApp")


### PR DESCRIPTION
- add new module for 2D matrix barcodes in Compose Multiplatform
- implement pure KMP Data Matrix (ECC 200) encoder supporting square and rectangular symbols
- implement pure KMP Aztec Code encoder supporting Compact and Full symbols
- support custom module styling (default, rounded corners, circle) and brush shaders
- add unit tests for both encoders and integrate into the example app
- update README with installation and usage guides